### PR TITLE
Add PriorityLevel to Bug with default value and unit test for High 

### DIFF
--- a/BugTracker.Core/Bug.cs
+++ b/BugTracker.Core/Bug.cs
@@ -1,6 +1,12 @@
-
 namespace BugTracker.Core
 {
+    public enum PriorityLevel
+    {
+        Low,
+        Medium,
+        High
+    }
+
     public class Bug
     {
         private static int _idSeed = 1;
@@ -10,6 +16,8 @@ namespace BugTracker.Core
         public BugStatus Status { get; private set; }
         public string AssignedToDeveloper { get; set; }  // New property
         public string? AttachmentUrl { get; set; }
+        public PriorityLevel Priority { get; set; } = PriorityLevel.Medium;
+
         public Bug(string title, string description)
         {
             if (string.IsNullOrWhiteSpace(title))

--- a/BugTracker.Tests/BugTests.cs
+++ b/BugTracker.Tests/BugTests.cs
@@ -72,5 +72,15 @@ namespace BugTracker.Tests
             bug.AttachmentUrl = "http://example.com/image.png";
             Assert.Equal("http://example.com/image.png", bug.AttachmentUrl);
         }
+
+        [Fact]
+        public void Bug_Priority_CanBeSetToHigh()
+        {
+            var bug = new Bug("Critical Bug", "This bug breaks the app.");
+            bug.Priority = PriorityLevel.High;
+
+            Assert.Equal(PriorityLevel.High, bug.Priority);
+        }
+
     }
 }


### PR DESCRIPTION
This PR introduces a PriorityLevel property (Low, Medium, High) to the Bug class with a default value of Medium. This helps categorize and triage bugs effectively. 
A unit test was added to confirm that Priority can be updated to High.
