### PR TITLE
Feature: Add EstimatedFixTimeHours to Bug class

### DIFF
--- a/BugTracker.Core/Bug.cs
+++ b/BugTracker.Core/Bug.cs
@@ -1,15 +1,21 @@
-
 namespace BugTracker.Core
 {
     public class Bug
     {
         private static int _idSeed = 1;
+
         public int Id { get; }
         public string Title { get; }
         public string Description { get; set; }
         public BugStatus Status { get; private set; }
-        public string AssignedToDeveloper { get; set; }  // New property
+        public string AssignedToDeveloper { get; set; }
         public string? AttachmentUrl { get; set; }
+
+        /// <summary>
+        /// Estimated time in hours to fix the bug (optional).
+        /// </summary>
+        public int? EstimatedFixTimeHours { get; set; }
+
         public Bug(string title, string description)
         {
             if (string.IsNullOrWhiteSpace(title))

--- a/BugTracker.Tests/BugTests.cs
+++ b/BugTracker.Tests/BugTests.cs
@@ -72,5 +72,14 @@ namespace BugTracker.Tests
             bug.AttachmentUrl = "http://example.com/image.png";
             Assert.Equal("http://example.com/image.png", bug.AttachmentUrl);
         }
+
+        [Fact]
+        public void Bug_EstimatedFixTime_CanBeSetAndRetrieved()
+        {
+            var bug = new Bug("Slow loading", "Page takes too long");
+            bug.EstimatedFixTimeHours = 5;
+            Assert.Equal(5, bug.EstimatedFixTimeHours);
+        }
+
     }
 }


### PR DESCRIPTION
## 🧠 Feature Overview
This feature adds an `EstimatedFixTimeHours` property to the `Bug` class, which allows developers to track how long a bug might take to resolve. The property is optional and nullable.

## 🧪 Testing
- Added unit test `Bug_EstimatedFixTime_CanBeSetAndRetrieved`
- All tests pass

## 📄 Documentation
- XML comment included for `EstimatedFixTimeHours`
- README updated with feature summary and test instructions

## 💬 Reflection
This enhancement simulates adding a new requirement mid-development. I used a feature branch and test-driven development to safely add and verify the functionality. By keeping it isolated, I ensured that nothing else in the app broke. This mirrors real-world agile workflows and version control discipline.
